### PR TITLE
feat: 프로젝트 초기 설정 및 유저 로그인 API, 커플 등록 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### secret ###
+application-mysql.properties

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,21 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.projectlombok:lombok:1.18.22'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'mysql:mysql-connector-java:8.0.32'
+	implementation("org.springframework.boot:spring-boot-starter-log4j2")
+
+	modules {
+		module("org.springframework.boot:spring-boot-starter-logging") {
+			replacedBy("org.springframework.boot:spring-boot-starter-log4j2")
+		}
+	}
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/OrangeCorps/LBridge/Config.java
+++ b/src/main/java/OrangeCorps/LBridge/Config.java
@@ -3,8 +3,8 @@ package OrangeCorps.LBridge;
 public class Config {
     public final static String USER_SAVE_SUCCESS = "User saved successfully: {}";
     public final static String NOT_FOUND_USER = "User not found\n";
-    public final static String NOT_FOUND_COUPLE_USER = "coupleUser not found\n";
-    public final static String COUPLE_LINK_SUCCESS = "coupleUser not found\n";
+    public final static String NOT_FOUND_COUPLE_USER = "User Or CoupleUser not found\n";
+    public final static String COUPLE_LINK_SUCCESS = "Couple Register Success\n";
 
     public final static String USER_SAVE_ERROR = "Error saving user";
 

--- a/src/main/java/OrangeCorps/LBridge/Config.java
+++ b/src/main/java/OrangeCorps/LBridge/Config.java
@@ -1,0 +1,13 @@
+package OrangeCorps.LBridge;
+
+public class Config {
+    public final static String USER_SAVE_SUCCESS = "User saved successfully: {}";
+    public final static String NOT_FOUND_USER = "User not found\n";
+    public final static String NOT_FOUND_COUPLE_USER = "coupleUser not found\n";
+    public final static String COUPLE_LINK_SUCCESS = "coupleUser not found\n";
+
+    public final static String USER_SAVE_ERROR = "Error saving user";
+
+    public final static Integer PAIR_OF_COUPLE = 2;
+
+}

--- a/src/main/java/OrangeCorps/LBridge/Controller/UserController.java
+++ b/src/main/java/OrangeCorps/LBridge/Controller/UserController.java
@@ -1,0 +1,50 @@
+package OrangeCorps.LBridge.Controller;
+
+import OrangeCorps.LBridge.DTO.UserDTO;
+import OrangeCorps.LBridge.Entity.User;
+import OrangeCorps.LBridge.Repository.UserRepository;
+import OrangeCorps.LBridge.Service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import static OrangeCorps.LBridge.Config.*;
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+
+    @PostMapping("/user/login")
+    public ResponseEntity<String> userRegist(@RequestBody UserDTO userDTO){
+        try {
+            User user = convertToUserEntity(userDTO);
+            userRepository.save(user);
+            log.info(USER_SAVE_SUCCESS, user.getUser_name());
+            return ResponseEntity.ok(String.format(USER_SAVE_SUCCESS, user.getUser_name()));
+        } catch (Exception e) {
+            log.error(USER_SAVE_ERROR, e);
+            return new ResponseEntity<>(USER_SAVE_ERROR, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/user/couple")
+    public ResponseEntity<String> linkUserToCouple(@RequestParam String userId , @RequestParam String coupleId) {
+        return userService.linkCouple(userId,coupleId);
+    }
+
+    private User convertToUserEntity(UserDTO userDTO) {
+            return new User(userDTO);
+    }
+
+}

--- a/src/main/java/OrangeCorps/LBridge/DTO/UserDTO.java
+++ b/src/main/java/OrangeCorps/LBridge/DTO/UserDTO.java
@@ -1,0 +1,18 @@
+package OrangeCorps.LBridge.DTO;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@RequiredArgsConstructor
+public class UserDTO {
+    private String userId;
+    private String user_name;
+    private String country;
+    private String tel;
+    private LocalDate birth;
+    private String coupleId;
+}

--- a/src/main/java/OrangeCorps/LBridge/Entity/User.java
+++ b/src/main/java/OrangeCorps/LBridge/Entity/User.java
@@ -50,8 +50,9 @@ public class User {
         coupleId = userDTO.getCoupleId();
     }
 
-    public User updateCoupleId(String newCoupleId) {
-        return new User(this.userId, this.user_name, this.country, this.tel, this.birth, newCoupleId);
+    public void updateCoupleId(String newCoupleId) {
+        this.coupleId = newCoupleId;
+        return;
     }
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Entity/User.java
+++ b/src/main/java/OrangeCorps/LBridge/Entity/User.java
@@ -1,0 +1,57 @@
+package OrangeCorps.LBridge.Entity;
+
+import OrangeCorps.LBridge.DTO.UserDTO;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="User") // 미 사용시 클래스이름 == 테이블이름
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @Column(length=128)
+    private String userId;
+
+    @Column(length=128)
+    private String user_name;
+
+    @Column(length=128)
+    private String country;
+
+    @Column(length=32)
+    private String tel;
+
+    @Column
+    private LocalDate birth;
+
+    @Column(length=128)
+    private String coupleId;
+
+    public User(UserDTO userDTO){
+        userId = userDTO.getUserId();
+        user_name = userDTO.getUser_name();
+        country = userDTO.getCountry();
+        tel = userDTO.getTel();
+        birth = userDTO.getBirth();
+        coupleId = userDTO.getCoupleId();
+    }
+
+    public User updateCoupleId(String newCoupleId) {
+        return new User(this.userId, this.user_name, this.country, this.tel, this.birth, newCoupleId);
+    }
+
+}

--- a/src/main/java/OrangeCorps/LBridge/Repository/UserRepository.java
+++ b/src/main/java/OrangeCorps/LBridge/Repository/UserRepository.java
@@ -1,0 +1,14 @@
+package OrangeCorps.LBridge.Repository;
+
+import OrangeCorps.LBridge.Entity.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String>{
+
+    //값이 없을 경우 null 반환
+    User findByUserId(String userId);
+}
+

--- a/src/main/java/OrangeCorps/LBridge/Service/UserService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/UserService.java
@@ -50,8 +50,8 @@ public class UserService {
     public void registCouple(String userId,String coupleId){
         Optional<User> optionalUser = userRepository.findById(userId);
         User existingUser = optionalUser.get();
-        User updatedUser = existingUser.updateCoupleId(coupleId);
+        existingUser.updateCoupleId(coupleId);
 
-        userRepository.save(updatedUser);
+        userRepository.save(existingUser);
     }
 }

--- a/src/main/java/OrangeCorps/LBridge/Service/UserService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/UserService.java
@@ -1,0 +1,57 @@
+package OrangeCorps.LBridge.Service;
+
+import OrangeCorps.LBridge.Entity.User;
+import OrangeCorps.LBridge.Repository.UserRepository;
+import OrangeCorps.LBridge.Validator.UserValidator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import static OrangeCorps.LBridge.Config.*;
+
+@Service
+public class UserService {
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    UserValidator userValidator;
+
+    public ResponseEntity<String> linkCouple(String userId, String coupleId) {
+
+        List<User> users = findBothUser(userId, coupleId);
+        boolean isBothExisted = userValidator.validateUserListLength(users,PAIR_OF_COUPLE);
+
+        if(!isBothExisted)
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(NOT_FOUND_COUPLE_USER);
+
+        registCouple(userId,coupleId);
+        return ResponseEntity.ok(COUPLE_LINK_SUCCESS);
+    }
+
+    public List<User> findBothUser(String userId, String coupleId) {
+        List<User> users = new ArrayList<>();
+        User userById = userRepository.findById(userId).orElse(null);
+        User userByCoupleId = userRepository.findByUserId(coupleId);
+
+        if (userById != null) {
+            users.add(userById);
+        }
+
+        if (userByCoupleId != null) {
+            users.add(userByCoupleId);
+        }
+        return users;
+    }
+
+    public void registCouple(String userId,String coupleId){
+        Optional<User> optionalUser = userRepository.findById(userId);
+        User existingUser = optionalUser.get();
+        User updatedUser = existingUser.updateCoupleId(coupleId);
+
+        userRepository.save(updatedUser);
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Validator/UserValidator.java
+++ b/src/main/java/OrangeCorps/LBridge/Validator/UserValidator.java
@@ -1,0 +1,12 @@
+package OrangeCorps.LBridge.Validator;
+
+import OrangeCorps.LBridge.Entity.User;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserValidator {
+    public boolean validateUserListLength(List<User> users,int required){
+        return users.size()==required;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
+spring.profiles.include = mysql
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
 
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 60초마다 설정 파일의 변경을 확인 하여 변경시 갱신 -->
+<configuration scan="true" scanPeriod="60 seconds">
+
+
+    <!--Environment 내의 프로퍼티들을 개별적으로 설정할 수도 있다.-->
+    <springProperty scope="context" name="LOG_LEVEL" source="logging.level.root"/>
+
+    <!-- log file path -->
+    <property name="LOG_PATH" value="./logs"/>
+    <!-- log file name -->
+    <property name="LOG_FILE_NAME" value="logs"/>
+    <!-- err log file name -->
+    <property name="ERR_LOG_FILE_NAME" value="err_log"/>
+    <!-- pattern -->
+    <property name="LOG_PATTERN"
+              value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
+
+    <!-- Console Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- File Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일경로 설정 -->
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+        <!-- 출력패턴 설정-->
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+
+        </encoder>
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- .gz,.zip 등을 넣으면 자동 일자별 로그파일 압축 -->
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log.zip</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최고 용량 kb, mb, gb -->
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 일자별 로그파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거-->
+            <!--  <maxHistory>30</maxHistory>-->
+            <!--<MinIndex>1</MinIndex> <MaxIndex>10</MaxIndex>-->
+        </rollingPolicy>
+    </appender>
+
+    <!-- 에러의 경우 파일에 로그 처리 -->
+    <appender name="Error" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>error</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_PATH}/${ERR_LOG_FILE_NAME}.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- .gz,.zip 등을 넣으면 자동 일자별 로그파일 압축 -->
+            <fileNamePattern>${LOG_PATH}/${ERR_LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최고 용량 kb, mb, gb -->
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 일자별 로그파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거-->
+            <!--  <maxHistory>30</maxHistory>-->
+        </rollingPolicy>
+    </appender>
+
+    <!-- root레벨 설정 -->
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="Error"/>
+    </root>
+
+    <logger name="org.apache.ibatis" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="Error"/>
+    </logger>
+
+    <!-- log4jdbc 옵션 설정 -->
+    <logger name="jdbc" level="OFF"/>
+    <!-- 커넥션 open close 이벤트를 로그로 남긴다. -->
+    <logger name="jdbc.connection" level="OFF"/>
+    <!-- SQL문만을 로그로 남기며, PreparedStatement일 경우 관련된 argument 값으로 대체된 SQL문이 보여진다. -->
+    <logger name="jdbc.sqlonly"
+            level="OFF"/> <!-- SQL문과 해당 SQL을 실행시키는데 수행된 시간 정보(milliseconds)를 포함한다. -->
+    <logger name="jdbc.sqltiming" level="DEBUG"/>
+    <!-- ResultSet을 제외한 모든 JDBC 호출 정보를 로그로 남긴다. 많은 양의 로그가 생성되므로 특별히 JDBC 문제를 추적해야 할 필요가 있는 경우를 제외하고는 사용을 권장하지 않는다. -->
+    <logger name="jdbc.audit" level="OFF"/>
+    <!-- ResultSet을 포함한 모든 JDBC 호출 정보를 로그로 남기므로 매우 방대한 양의 로그가 생성된다. -->
+    <logger name="jdbc.resultset" level="OFF"/>
+    <!-- SQL 결과 조회된 데이터의 table을 로그로 남긴다. -->
+    <logger name="jdbc.resultsettable" level="OFF"/>
+
+</configuration>

--- a/src/test/java/OrangeCorps/LBridge/UserTest.java
+++ b/src/test/java/OrangeCorps/LBridge/UserTest.java
@@ -1,0 +1,93 @@
+package OrangeCorps.LBridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.util.AssertionErrors.assertNotNull;
+
+import OrangeCorps.LBridge.DTO.UserDTO;
+import OrangeCorps.LBridge.Entity.User;
+import OrangeCorps.LBridge.Repository.UserRepository;
+import OrangeCorps.LBridge.Service.UserService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+
+@SpringBootTest
+@Transactional
+public class UserTest {
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DisplayName("user가 정상적으로 등록되는지 테스트")
+    void testUserLogin() {
+
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUserId("test22");
+
+        User user = new User(userDTO);
+
+        userRepository.save(user);
+
+        // 데이터베이스에 해당 유저가 존재하는지 확인
+        boolean userExists = userRepository.existsById("test22");
+
+        // 해당 유저가 존재해야 테스트가 성공
+        assertTrue(userExists, "User should exist in the database");
+    }
+
+    @Test
+    @DisplayName("user가 userId(기본키)가 없을 때 등록되지 않는지 테스트")
+    void testUserLoginWithoutUserId() {
+        UserDTO userDTO = new UserDTO();
+        // userId를 설정하지 않음
+
+        User user = new User(userDTO);
+
+        // 예외(DataIntegrityViolationException)이 발생해야 함
+        assertThrows(JpaSystemException.class, () -> userRepository.save(user),
+                "User should not be saved without userId");
+    }
+
+    @Test
+    @DisplayName("couple이 잘 등록되는지 테스트")
+    void testCoupleRegist(){
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUserId("test1");
+        User user1 = new User(userDTO);
+        userDTO.setUserId("test2");
+        User user2 = new User(userDTO);
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        userService.linkCouple("test1","test2");
+
+
+        assertEquals(userRepository.findByUserId("test1").getCoupleId(),user2.getUserId());
+    }
+
+    @Test
+    @DisplayName("coupleId가 존재하지 않을 때 등록되지 않는지 테스트")
+    void testIsNotRegistWhenCoupleNotExist(){
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUserId("test1");
+        User user1 = new User(userDTO);
+
+        userRepository.save(user1);
+
+        userService.linkCouple("test1","test2");
+
+        assertEquals(user1.getCoupleId(),null);
+
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature

### 작업사항 :memo:
프로젝트의 기본 설정과 데이터베이스 연동을 마쳤습니다.
80833b6 커밋에서 알 수 있듯이 propertie에 데이터베이스 관련 옵션을 숨겼습니다.
로컬에서 실행하기 위해서는 `application-mysql.properties.xml` 파일을 생성 후 
```
spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
spring.datasource.url=jdbc:mysql://localhost:3306/lbridge?serverTimezone=Asia/Seoul
spring.datasource.username= mysql ID
spring.datasource.password=mysql PW
```
해당 내용을 적어주세요

그 외에 User 관련 엔티티/DTO를 생성했고 (6740bea , 5a462f4) JPA를 활용해 해당 데이터의 테이블이 자동 생성되도록
설정하였습니다.

`POST` `/user/login`
해당 API를 사용할때는 body에 다음 내용을 적어서 요청을 보내주세요
예시)
```
{
    "userId" : "testId",
    "user_name" : "testName",
    "country" : "testCountry",
    "tel" : "01034804032",
    "birth" : "2000-02-10",
    "coupleId" : "testId2"
}
```

`POST` `/user/couple`
해당 API를 사용할 때는 파라미터를 다음과 같 적어서 요청을 보내주세요.

예시)
```
localhost:8080/user/couple?userId=testId&coupleId=testId3
```




### 테스트 방법

`POST` `/user/login`
포스트맨에서 다음과 같이 테스트 하시면 됩니다.
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/de98018f-a597-4c95-90e4-d155ca923f25)

**주의사항 : 반드시 raw의 json 옵션을 선택해주시고, 데이터 형식에 어긋나지 않게 요청을 보내주세요**

`POST` `/user/couple`
포스트맨에서 다음과 같이 테스트 하시면 됩니다.
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/007ce857-e33d-4c79-9246-701f51f0b7c9)





### 테스트 결과
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/a3f7d1c1-6299-4fc4-84d3-41c2400b3193)
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/21f4c548-5c9c-4ebf-9b79-9033afb53711)
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/72345099-2b68-4b39-9391-796d61adb27f)
