### PR TITLE
feat: NewsAPI 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### secret ###
-application-mysql.properties
+application-*

--- a/src/main/java/OrangeCorps/LBridge/Config.java
+++ b/src/main/java/OrangeCorps/LBridge/Config.java
@@ -10,4 +10,12 @@ public class Config {
 
     public final static Integer PAIR_OF_COUPLE = 2;
 
+    public final static String QUERY_IS = "?q=";
+
+    public final static String My_API_KEY_IS = "&api-key=";
+
+    public final static Integer NEWS_START_INDEX = 0;
+
+    public final static Integer NEWS_END_INDEX =5;
+
 }

--- a/src/main/java/OrangeCorps/LBridge/Controller/NewsController.java
+++ b/src/main/java/OrangeCorps/LBridge/Controller/NewsController.java
@@ -1,0 +1,23 @@
+package OrangeCorps.LBridge.Controller;
+
+
+import OrangeCorps.LBridge.DTO.NewsDTO;
+import OrangeCorps.LBridge.Service.News.NewsService;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class NewsController {
+
+    @Autowired
+    private NewsService newsService;
+
+    @GetMapping("news")
+    public List<NewsDTO> crawlNews(@RequestParam String userId) {
+            return newsService.getTenOfNewsOfCouple(userId);
+    }
+
+}

--- a/src/main/java/OrangeCorps/LBridge/DTO/NewsApiResponse.java
+++ b/src/main/java/OrangeCorps/LBridge/DTO/NewsApiResponse.java
@@ -1,0 +1,44 @@
+package OrangeCorps.LBridge.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class NewsApiResponse {
+
+    @JsonProperty("response")
+    private NewsApiResponseBody response;
+
+    @Getter
+    public static class NewsApiResponseBody {
+
+        @JsonProperty("docs")
+        private List<Docs> docs;
+
+        @Getter
+        public static class Docs {
+
+            @JsonProperty("web_url")
+            private  String url;
+
+            @JsonProperty("headline")
+            private Headline headline;
+
+            @JsonProperty("abstract")
+            private String summary;
+
+            @JsonProperty("pub_date")
+            private String pubDate;
+
+            @Getter
+            public static class Headline {
+
+                @JsonProperty("main")
+                private String main;
+
+            }
+        }
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/DTO/NewsDTO.java
+++ b/src/main/java/OrangeCorps/LBridge/DTO/NewsDTO.java
@@ -1,0 +1,19 @@
+package OrangeCorps.LBridge.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class NewsDTO {
+    private String url;
+    private String headLine;
+    private String summary;
+    private String published_date;
+}

--- a/src/main/java/OrangeCorps/LBridge/LBridgeApplication.java
+++ b/src/main/java/OrangeCorps/LBridge/LBridgeApplication.java
@@ -2,6 +2,9 @@ package OrangeCorps.LBridge;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class LBridgeApplication {
@@ -9,5 +12,11 @@ public class LBridgeApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(LBridgeApplication.class, args);
 	}
+
+	@Bean
+	public RestTemplate restTemplate(RestTemplateBuilder builder) {
+		return builder.build();
+	}
+
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Service/CoupleService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/CoupleService.java
@@ -1,0 +1,25 @@
+package OrangeCorps.LBridge.Service;
+
+import OrangeCorps.LBridge.Entity.User;
+import OrangeCorps.LBridge.Repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CoupleService {
+    @Autowired
+    UserRepository userRepository;
+
+    public String findCoupleOfUser(String userId){
+        User user = userRepository.findByUserId(userId);
+        if(user.getCoupleId() == null){
+
+        }
+        return user.getCoupleId();
+    }
+
+    public String findCountryOfCouple(String userId){
+        String coupleId = findCoupleOfUser(userId);
+        return userRepository.findByUserId(coupleId).getCountry();
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Service/News/GetArticles.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/GetArticles.java
@@ -1,0 +1,16 @@
+package OrangeCorps.LBridge.Service.News;
+
+import OrangeCorps.LBridge.DTO.NewsApiResponse;
+import OrangeCorps.LBridge.DTO.NewsDTO;
+
+public interface GetArticles {
+
+    void setNewsAPIResponse(String APIUrl);
+
+    NewsDTO getArticle();
+    String getArticleUrl();
+    String getArticleSummary();
+    String getArticleHeadLine();
+    String getArticlePubDate();
+
+}

--- a/src/main/java/OrangeCorps/LBridge/Service/News/GetNYTimesArticles.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/GetNYTimesArticles.java
@@ -1,0 +1,72 @@
+package OrangeCorps.LBridge.Service.News;
+
+import OrangeCorps.LBridge.DTO.NewsApiResponse;
+import OrangeCorps.LBridge.DTO.NewsDTO;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class GetNYTimesArticles implements GetArticles {
+    private NewsApiResponse newsApiResponse;
+
+    private Integer idx;
+    @Autowired
+    private RestTemplate restTemplate;
+
+    public GetNYTimesArticles(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public void setOptions(String APIUrl , Integer idx){
+        setNewsAPIResponse(APIUrl);
+        setIdx(idx);
+    }
+
+    public void setNewsAPIResponse(String APIUrl){
+        this.newsApiResponse = restTemplate.getForObject(APIUrl, NewsApiResponse.class);
+    }
+
+    private void setIdx(Integer idx){
+        this.idx=idx;
+    }
+
+
+
+    @Override
+    public NewsDTO getArticle() {
+        return NewsDTO.builder()
+                .url(getArticleUrl())
+                .headLine(getArticleHeadLine())
+                .published_date(getArticlePubDate())
+                .summary(getArticleSummary())
+                .build();
+    }
+
+    @Override
+    public String getArticleUrl() {
+        return newsApiResponse.getResponse().getDocs().get(idx).getUrl();
+    }
+
+
+    @Override
+    public String getArticleHeadLine() {
+        return newsApiResponse.getResponse().getDocs().get(idx).getHeadline().getMain();
+    }
+
+    @Override
+    public String getArticlePubDate() {
+        return newsApiResponse.getResponse().getDocs().get(idx).getPubDate();
+    }
+
+    @Override
+    public String getArticleSummary() {
+        return newsApiResponse.getResponse().getDocs().get(idx).getSummary();
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
@@ -1,0 +1,60 @@
+package OrangeCorps.LBridge.Service.News;
+
+import static OrangeCorps.LBridge.Config.My_API_KEY_IS;
+import static OrangeCorps.LBridge.Config.QUERY_IS;
+
+import OrangeCorps.LBridge.DTO.NewsApiResponse;
+import OrangeCorps.LBridge.DTO.NewsDTO;
+import OrangeCorps.LBridge.Service.CoupleService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import static OrangeCorps.LBridge.Config.*;
+
+@Service
+public class NewsService {
+
+    @Autowired
+    CoupleService coupleService;
+
+    @Value("${news.api.url}")
+    private String apiUrl;
+
+    @Value("${news.api.key}")
+    private String apiKey;
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    public NewsDTO getNewsOfCouple(String userId,Integer idx) {
+        NewsDTO newsDTO;
+        String coupleCountry = coupleService.findCountryOfCouple(userId);
+        String APIUrl = makeUrl(coupleCountry);
+
+        GetNYTimesArticles getNYTimesArticles = new GetNYTimesArticles(restTemplate);
+        getNYTimesArticles.setOptions(APIUrl,idx);
+        newsDTO = getNYTimesArticles.getArticle();
+
+
+        return newsDTO;
+    }
+
+    public String makeUrl(String coupleCountry){
+        return apiUrl + QUERY_IS + coupleCountry + My_API_KEY_IS + apiKey;
+    }
+
+    public List<NewsDTO> getTenOfNewsOfCouple(String userId){
+        List<NewsDTO> newsDTOs=new ArrayList<>();
+        for(int idx=NEWS_START_INDEX; idx<NEWS_END_INDEX; idx++){
+            newsDTOs.add(getNewsOfCouple(userId,idx));
+        }
+        return newsDTOs;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,9 @@
-spring.profiles.include = mysql
+spring.profiles.include = mysql,apikey
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.jpa.hibernate.ddl-auto=update
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+news.api.url=https://api.nytimes.com/svc/search/v2/articlesearch.json
+

--- a/src/test/java/OrangeCorps/LBridge/NewsTest.java
+++ b/src/test/java/OrangeCorps/LBridge/NewsTest.java
@@ -1,0 +1,19 @@
+package OrangeCorps.LBridge;
+
+import OrangeCorps.LBridge.Service.News.NewsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class NewsTest {
+    @Autowired
+    private NewsService newsService;
+
+    @Test
+    @DisplayName("API 정상 수신 테스트")
+    void IsNewsAPISuccess(){
+        newsService.getTenOfNewsOfCouple("testId");
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
local ➡️ feature

### 변경 사항
뉴스 API 기능과 관련된 메서드를 구현하였습니다.

**주의사항**
application-apikey.properties 파일을 생성한 후, api key를 입력해주어야합니다.
api key는 노션 팀페이지 ➡️ Back-end ➡️ 인증 정보란에 명시해놓았습니다.


6967d48 커밋에서 엔드포인트를 확인 가능합니다.

**API 사용법**
`POST` `/news?userId=testId`
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/38e277b4-b847-434d-b844-0bcebcf3f445)





### 테스트 결과
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/fa5d0470-dc26-4d20-8d6b-fd567d29814f)
