### PR TITLE
feat: 뉴스 자동 수집기 구현 및 뉴스 API 수정

### DIFF
--- a/src/main/java/OrangeCorps/LBridge/Controller/NewsCallerController.java
+++ b/src/main/java/OrangeCorps/LBridge/Controller/NewsCallerController.java
@@ -1,0 +1,33 @@
+package OrangeCorps.LBridge.Controller;
+
+import OrangeCorps.LBridge.Service.News.NewsService;
+import OrangeCorps.LBridge.Service.News.ScheduledApiCaller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/news/caller")
+public class NewsCallerController {
+
+
+    @Autowired
+    ScheduledApiCaller scheduledApiCaller;
+
+    @GetMapping("/start")
+    public ResponseEntity<String> startCrawl(){
+        scheduledApiCaller.contextInitialized();
+        return ResponseEntity.ok("CRAWL START");
+    }
+
+    @GetMapping("/end")
+    public ResponseEntity<String> endCrawl(){
+        scheduledApiCaller.contextDestroyed();
+        return ResponseEntity.ok("CRAWL END");
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Controller/NewsController.java
+++ b/src/main/java/OrangeCorps/LBridge/Controller/NewsController.java
@@ -5,6 +5,7 @@ import OrangeCorps.LBridge.Domain.News.NewsDTO;
 import OrangeCorps.LBridge.Service.News.NewsService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,8 +17,9 @@ public class NewsController {
     private NewsService newsService;
 
     @GetMapping("news")
-    public List<NewsDTO> crawlNews(@RequestParam String userId) {
-            return newsService.getTenOfNewsOfCouple(userId);
+    public ResponseEntity<Object> crawlNews(@RequestParam String userId) {
+
+            return ResponseEntity.ok("Success");
     }
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Controller/UserController.java
+++ b/src/main/java/OrangeCorps/LBridge/Controller/UserController.java
@@ -10,8 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import static OrangeCorps.LBridge.Config.Config.*;
@@ -19,27 +21,32 @@ import static OrangeCorps.LBridge.Config.Config.*;
 @Slf4j
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/user")
 public class UserController {
 
     private final UserRepository userRepository;
     @Autowired
     private UserService userService;
 
-    @PostMapping("/user/login")
+    @PostMapping("/login")
     public ResponseEntity<String> userRegist(@RequestBody UserDTO userDTO) {
-        User user = convertToUserEntity(userDTO);
-        userRepository.save(user);
-        return ResponseEntity.ok(String.format(USER_SAVE_SUCCESS, user.getName()));
+        String userID = userService.saveUser(userDTO);
+        return ResponseEntity.ok("USER " + userID + " INSERT SUCCESSFULLY");
 
     }
 
-    @PostMapping("/user/couple")
-    public ResponseEntity<String> linkUserToCouple(@RequestParam String userId, @RequestParam String coupleId) {
-        return userService.linkCouple(userId, coupleId);
+    @PostMapping("/couple")
+    public ResponseEntity<String> linkUserToCouple(@RequestParam String uuid, @RequestParam String coupleId) {
+        userService.linkCouple(uuid, coupleId);
+        return ResponseEntity.ok(COUPLE_LINK_SUCCESS);
     }
 
-    private User convertToUserEntity(UserDTO userDTO) {
-        return new User(userDTO);
+    @GetMapping("/country")
+    public ResponseEntity<String> getUserCountry(@RequestParam String uuid){
+        String country= userService.findCountry(uuid);
+        return ResponseEntity.ok(country);
     }
+
+
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Domain/News/News.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/News/News.java
@@ -1,0 +1,35 @@
+package OrangeCorps.LBridge.Domain.News;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+
+@Entity
+@Getter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class News {
+
+    @Id
+    @Column(length=256)
+    private String url;
+    @Column(length=256)
+    private String headLine;
+    @Column(length=256)
+    private String summary;
+    @Column(length=128)
+    private String published_date;
+    @Column(length=128)
+    private String country;
+
+
+}

--- a/src/main/java/OrangeCorps/LBridge/Domain/News/NewsRepository.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/News/NewsRepository.java
@@ -1,0 +1,9 @@
+package OrangeCorps.LBridge.Domain.News;
+
+import OrangeCorps.LBridge.Domain.TID.TIDQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsRepository extends JpaRepository<News, String> {
+}

--- a/src/main/java/OrangeCorps/LBridge/Domain/User/UserRepository.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/User/UserRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, String>{
 
     //값이 없을 경우 null 반환
-    Optional<User> findByUserId(String userId);
+    Optional<User> findByUuid(String uuid);
 }
 

--- a/src/main/java/OrangeCorps/LBridge/Exception/LBridgeException.java
+++ b/src/main/java/OrangeCorps/LBridge/Exception/LBridgeException.java
@@ -1,6 +1,7 @@
 package OrangeCorps.LBridge.Exception;
 
 
+import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,5 +16,14 @@ public class LBridgeException {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
+    @ExceptionHandler
+    public ResponseEntity<String> ExceptionHandler(IllegalArgumentException e){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> ExceptionHandler(NoSuchElementException e){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Service/CoupleService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/CoupleService.java
@@ -2,29 +2,32 @@ package OrangeCorps.LBridge.Service;
 
 import OrangeCorps.LBridge.Domain.User.User;
 import OrangeCorps.LBridge.Domain.User.UserRepository;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import static OrangeCorps.LBridge.Config.Config.*;
 
 @Service
 public class CoupleService {
     @Autowired
     UserRepository userRepository;
 
-    public String findCoupleOfUser(String userId){
-        Optional<User> user = userRepository.findByUserId(userId);
+    public String findCoupleOfUser(String userId) {
+        Optional<User> user = userRepository.findByUuid(userId);
 
-        if(user.isPresent()){
-            return user.get().getCoupleId();
-        }
-        else{
-            throw new NullPointerException();
-        }
+        return userRepository.findByUuid(userId)
+                .map(User::getCoupleId)
+                .orElseThrow(() -> new NoSuchElementException(NOT_FOUND_COUPLE_USER));
+
     }
 
-    public String findCountryOfCouple(String userId){
+    public String findCountryOfCouple(String userId) {
+
         String coupleId = findCoupleOfUser(userId);
-        User coupleUser =userRepository.findByUserId(coupleId).get();
+        User coupleUser = userRepository.findByUuid(coupleId).get();
+        System.out.println(coupleUser.getCountry());
         return coupleUser.getCountry();
     }
 }

--- a/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
@@ -3,21 +3,34 @@ package OrangeCorps.LBridge.Service.News;
 import static OrangeCorps.LBridge.Config.Config.My_API_KEY_IS;
 import static OrangeCorps.LBridge.Config.Config.QUERY_IS;
 
+import OrangeCorps.LBridge.Domain.News.News;
 import OrangeCorps.LBridge.Domain.News.NewsDTO;
+import OrangeCorps.LBridge.Domain.News.NewsRepository;
+import OrangeCorps.LBridge.Domain.User.User;
+import OrangeCorps.LBridge.Domain.User.UserRepository;
 import OrangeCorps.LBridge.Service.CoupleService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Scanner;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
 import static OrangeCorps.LBridge.Config.Config.*;
 
 @Service
 public class NewsService {
 
     @Autowired
-    CoupleService coupleService;
+    private CoupleService coupleService;
+
+    @Autowired
+    private NewsRepository newsRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Value("${news.api.url}")
     private String apiUrl;
@@ -28,29 +41,61 @@ public class NewsService {
     @Autowired
     RestTemplate restTemplate;
 
-    public NewsDTO getNewsOfCouple(String userId,Integer idx) {
+    public NewsDTO getNewsOfCouple(Integer idx,String country) {
         NewsDTO newsDTO;
-        String coupleCountry = coupleService.findCountryOfCouple(userId);
-        String APIUrl = makeUrl(coupleCountry);
+
+        String APIUrl = makeUrl(country);
 
         GetNYTimesArticles getNYTimesArticles = new GetNYTimesArticles(restTemplate);
-        getNYTimesArticles.setOptions(APIUrl,idx);
+        getNYTimesArticles.setOptions(APIUrl, idx);
         newsDTO = getNYTimesArticles.getArticle();
-
 
         return newsDTO;
     }
 
-    public String makeUrl(String coupleCountry){
-        return apiUrl + QUERY_IS + coupleCountry + My_API_KEY_IS + apiKey;
+    public String makeUrl(String country) {
+        return apiUrl + QUERY_IS + country + My_API_KEY_IS + apiKey;
     }
 
-    public List<NewsDTO> getTenOfNewsOfCouple(String userId){
-        List<NewsDTO> newsDTOs=new ArrayList<>();
-        for(int idx=NEWS_START_INDEX; idx<NEWS_END_INDEX; idx++){
-            newsDTOs.add(getNewsOfCouple(userId,idx));
+    public List<NewsDTO> getNewsesOfCouple(String country) {
+        List<NewsDTO> newsDTOs = new ArrayList<>();
+        for (int idx = NEWS_START_INDEX; idx < NEWS_END_INDEX; idx++) {
+            newsDTOs.add(getNewsOfCouple(idx, country));
         }
         return newsDTOs;
+    }
+
+    public void saveNews() {
+        List<NewsDTO> newsDTOs = new ArrayList<>();
+
+        List<String> distinctCountries = getDistinctCountries();
+
+        for(String country : distinctCountries) {
+            newsDTOs = getNewsesOfCouple(country);
+
+            for (NewsDTO newsDTO : newsDTOs) {
+
+                // News 엔티티 생성 및 값 설정
+                News newsEntity = News.builder()
+                        .url(newsDTO.getUrl())
+                        .headLine(newsDTO.getHeadLine())
+                        .summary(newsDTO.getSummary())
+                        .published_date(newsDTO.getPublished_date())
+                        .country(country)
+                        .build();
+
+                newsRepository.save(newsEntity);
+            }
+        }
+    }
+
+    private List<String> getDistinctCountries() {
+        List<User> allUsers = userRepository.findAll();
+
+        return allUsers.stream()
+                .map(User::getCountry)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Service/News/ScheduledApiCaller.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/ScheduledApiCaller.java
@@ -1,0 +1,61 @@
+package OrangeCorps.LBridge.Service.News;
+
+import jakarta.annotation.PostConstruct;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@NoArgsConstructor
+@Component
+public class ScheduledApiCaller {
+
+    private ScheduledExecutorService scheduler;
+
+    @Autowired
+    NewsService newsService;
+
+    public void contextInitialized() {
+        // 서버가 시작될 때 실행될 코드
+        System.out.println("뉴스 수집을 시작합니다. \n 간격: 하루");
+
+        // ScheduledExecutorService 생성
+        scheduler = Executors.newScheduledThreadPool(1);
+
+        // 작업을 수행할 Runnable 객체 생성
+        Runnable apiCallTask = () -> {
+            try {
+                // API 호출 메서드 호출
+                callApi();
+            } catch (Exception e) {
+                e.printStackTrace(); // 예외 처리
+            }
+        };
+
+        // 일정 주기로 작업 예약
+        long initialDelay = 60; // 초기 지연 (0초)
+        long period = 24*60*60; // 주기 (초 단위, 여기서는 24시간)
+        scheduler.scheduleAtFixedRate(apiCallTask, initialDelay, period, TimeUnit.SECONDS);
+    }
+
+    public void contextDestroyed() {
+        // 서버가 종료될 때 실행될 코드
+        System.out.println("수집을 종료됩니다.");
+
+        // 스케줄러 종료
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdown();
+        }
+    }
+
+    @PostConstruct
+    private void callApi() {
+        newsService.saveNews();
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Service/UserService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/UserService.java
@@ -1,6 +1,7 @@
 package OrangeCorps.LBridge.Service;
 
 import OrangeCorps.LBridge.Domain.User.User;
+import OrangeCorps.LBridge.Domain.User.UserDTO;
 import OrangeCorps.LBridge.Domain.User.UserRepository;
 import OrangeCorps.LBridge.Service.Validator.UserValidator;
 import java.util.ArrayList;
@@ -22,34 +23,34 @@ public class UserService {
     @Autowired
     UserValidator userValidator;
 
-    public ResponseEntity<String> linkCouple(String userId, String coupleId) {
+    public void linkCouple(String userId, String coupleId) {
 
         List<User> users = findBothUser(userId, coupleId);
 
-        if(userValidator.validateUserListLength(users,PAIR_OF_COUPLE))
+        if(!userValidator.validateUserListLength(users,PAIR_OF_COUPLE))
             throw new NullPointerException(NOT_FOUND_USER);
 
         registCouple(userId,coupleId);
-        return ResponseEntity.ok(COUPLE_LINK_SUCCESS);
+        return;
     }
 
     public List<User> findBothUser(String userId, String coupleId) {
         List<User> users = new ArrayList<>();
         Optional<User> userById = userRepository.findById(userId);
-        Optional<User> userByCoupleId = userRepository.findByUserId(coupleId);
+        Optional<User> userByCoupleId = userRepository.findById(coupleId);
 
         if(userById.isPresent()){
             users.add(userById.get());
         }
         else{
-            throw new NullPointerException(NOT_FOUND_USER);
+            throw new IllegalArgumentException(NOT_FOUND_USER);
         }
 
         if(userByCoupleId.isPresent()){
             users.add(userByCoupleId.get());
         }
         else{
-            throw new NullPointerException(NOT_FOUND_COUPLE_USER);
+            throw new IllegalArgumentException(NOT_FOUND_COUPLE_USER);
         }
 
         return users;
@@ -61,5 +62,23 @@ public class UserService {
         existingUser.updateCoupleId(coupleId);
 
         userRepository.save(existingUser);
+    }
+
+    public String findCountry(String uuid){
+        Optional<User> optionalUser = userRepository.findByUuid(uuid);
+        if(optionalUser.isEmpty()){
+            throw new IllegalArgumentException(NOT_FOUND_USER);
+        }
+        return optionalUser.get().getCountry();
+    }
+
+    public String saveUser(UserDTO userDTO){
+        User user = convertToUserEntity(userDTO);
+        userRepository.save(user);
+
+        return user.getUuid();
+    }
+    private User convertToUserEntity(UserDTO userDTO) {
+        return new User(userDTO);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 news.api.url=https://api.nytimes.com/svc/search/v2/articlesearch.json
 
+spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/src/test/java/OrangeCorps/LBridge/NewsTest.java
+++ b/src/test/java/OrangeCorps/LBridge/NewsTest.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Transactional
 public class NewsTest {
     @Autowired
     private NewsService newsService;
@@ -14,6 +16,5 @@ public class NewsTest {
     @Test
     @DisplayName("API 정상 수신 테스트")
     void IsNewsAPISuccess(){
-        newsService.getTenOfNewsOfCouple("testId");
     }
 }

--- a/src/test/java/OrangeCorps/LBridge/UserTest.java
+++ b/src/test/java/OrangeCorps/LBridge/UserTest.java
@@ -29,7 +29,7 @@ public class UserTest {
     void testUserLogin() {
 
         UserDTO userDTO = new UserDTO();
-        userDTO.setUserId("test22");
+        userDTO.setUuid("test22");
 
         User user = new User(userDTO);
 
@@ -59,9 +59,9 @@ public class UserTest {
     @DisplayName("couple이 잘 등록되는지 테스트")
     void testCoupleRegist(){
         UserDTO userDTO = new UserDTO();
-        userDTO.setUserId("test1");
+        userDTO.setUuid("test1");
         User user1 = new User(userDTO);
-        userDTO.setUserId("test2");
+        userDTO.setUuid("test2");
         User user2 = new User(userDTO);
 
         userRepository.save(user1);
@@ -71,14 +71,14 @@ public class UserTest {
 
 
 
-        assertEquals(userRepository.findByUserId("test1").get().getCoupleId(),user2.getUserId());
+        assertEquals(userRepository.findByUuid("test1").get().getCoupleId(),user2.getUuid());
     }
 
     @Test
     @DisplayName("coupleId가 존재하지 않을 때 등록되지 않는지 테스트")
     void testIsNotRegistWhenCoupleNotExist(){
         UserDTO userDTO = new UserDTO();
-        userDTO.setUserId("test1");
+        userDTO.setUuid("test1");
         User user1 = new User(userDTO);
 
         userRepository.save(user1);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature

### 변경 사항
30d188b 뉴스 수집기 구현
구현방식: /news/caller/start API 호출 시 수집기 가동 / 24시간 단위로 사용자가 등록한 나라 전부에 대한 뉴스 API 호출

5962f3a 컨트롤러 리턴 방식 status와 message를 볼 수 있는 형태로 변경 & 임시 API 수정

### 테스트 결과
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/09c8b126-6bab-413c-b3cd-5be237878862)

