### PR TITLE
feat: 유저가 최신 News를 받아오는 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### secret ###
 application-*
+application.yml

--- a/src/main/java/OrangeCorps/LBridge/Controller/NewsController.java
+++ b/src/main/java/OrangeCorps/LBridge/Controller/NewsController.java
@@ -1,25 +1,33 @@
 package OrangeCorps.LBridge.Controller;
 
 
+import OrangeCorps.LBridge.Domain.News.News;
 import OrangeCorps.LBridge.Domain.News.NewsDTO;
 import OrangeCorps.LBridge.Service.News.NewsService;
+import OrangeCorps.LBridge.Service.UserService;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class NewsController {
 
     @Autowired
     private NewsService newsService;
 
-    @GetMapping("news")
-    public ResponseEntity<Object> crawlNews(@RequestParam String userId) {
+    @Autowired
+    private UserService userService;
 
-            return ResponseEntity.ok("Success");
+    @GetMapping("/news")
+    public ResponseEntity<List<News>> getLatestNews(@RequestParam String userId) {
+        List<News> latestNews = newsService.getLatestNewsByCountry(userId);
+        return new ResponseEntity<>(latestNews, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Domain/News/News.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/News/News.java
@@ -27,7 +27,7 @@ public class News {
     @Column(length=256)
     private String summary;
     @Column(length=128)
-    private String published_date;
+    private String publishedDate;
     @Column(length=128)
     private String country;
 

--- a/src/main/java/OrangeCorps/LBridge/Domain/News/NewsDTO.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/News/NewsDTO.java
@@ -15,5 +15,5 @@ public class NewsDTO {
     private String url;
     private String headLine;
     private String summary;
-    private String published_date;
+    private String publishedDate;
 }

--- a/src/main/java/OrangeCorps/LBridge/Domain/News/NewsRepository.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/News/NewsRepository.java
@@ -1,9 +1,12 @@
 package OrangeCorps.LBridge.Domain.News;
 
 import OrangeCorps.LBridge.Domain.TID.TIDQuestion;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, String> {
+    List<News> findTop5ByCountryOrderByPublishedDateDesc(String country);
 }

--- a/src/main/java/OrangeCorps/LBridge/Domain/User/UserRepository.java
+++ b/src/main/java/OrangeCorps/LBridge/Domain/User/UserRepository.java
@@ -2,6 +2,8 @@ package OrangeCorps.LBridge.Domain.User;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,5 +11,8 @@ public interface UserRepository extends JpaRepository<User, String>{
 
     //값이 없을 경우 null 반환
     Optional<User> findByUuid(String uuid);
+
+    @Query("SELECT u.coupleId FROM User u WHERE u.uuid = :uuid")
+    Optional<String> findCoupleIdByUuid(@Param("uuid") String uuid);
 }
 

--- a/src/main/java/OrangeCorps/LBridge/Service/News/GetNYTimesArticles.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/GetNYTimesArticles.java
@@ -38,7 +38,7 @@ public class GetNYTimesArticles implements GetArticles {
         return NewsDTO.builder()
                 .url(getArticleUrl())
                 .headLine(getArticleHeadLine())
-                .published_date(getArticlePubDate())
+                .publishedDate(getArticlePubDate())
                 .summary(getArticleSummary())
                 .build();
     }

--- a/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
@@ -9,6 +9,7 @@ import OrangeCorps.LBridge.Domain.News.NewsRepository;
 import OrangeCorps.LBridge.Domain.User.User;
 import OrangeCorps.LBridge.Domain.User.UserRepository;
 import OrangeCorps.LBridge.Service.CoupleService;
+import OrangeCorps.LBridge.Service.UserService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -31,6 +32,9 @@ public class NewsService {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
 
     @Value("${news.api.url}")
     private String apiUrl;
@@ -80,7 +84,7 @@ public class NewsService {
                         .url(newsDTO.getUrl())
                         .headLine(newsDTO.getHeadLine())
                         .summary(newsDTO.getSummary())
-                        .published_date(newsDTO.getPublished_date())
+                        .publishedDate(newsDTO.getPublishedDate())
                         .country(country)
                         .build();
 
@@ -96,6 +100,13 @@ public class NewsService {
                 .map(User::getCountry)
                 .distinct()
                 .collect(Collectors.toList());
+    }
+
+    public List<News> getLatestNewsByCountry(String userId) {
+        String coupleId = userService.getCoupleIdByUuid(userId);
+        String country= userService.findCountry(coupleId);
+
+        return newsRepository.findTop5ByCountryOrderByPublishedDateDesc(country);
     }
 
 }

--- a/src/main/java/OrangeCorps/LBridge/Service/News/ScheduledApiCaller.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/ScheduledApiCaller.java
@@ -1,9 +1,7 @@
 package OrangeCorps.LBridge.Service.News;
 
 import jakarta.annotation.PostConstruct;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +52,6 @@ public class ScheduledApiCaller {
         }
     }
 
-    @PostConstruct
     private void callApi() {
         newsService.saveNews();
     }

--- a/src/main/java/OrangeCorps/LBridge/Service/UserService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/UserService.java
@@ -81,4 +81,10 @@ public class UserService {
     private User convertToUserEntity(UserDTO userDTO) {
         return new User(userDTO);
     }
+
+    public String getCoupleIdByUuid(String userId){
+        Optional<String> coupleIdOptional = userRepository.findCoupleIdByUuid(userId);
+
+        return coupleIdOptional.orElseThrow(() -> new IllegalArgumentException(NOT_FOUND_COUPLE_USER));
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature

### 변경 사항
`GET` `/news` API 구현
사용방법
- 매개변수
    - user_id : 유저 아이디
- 응답
    - `message`:
    - `resultCode`: 200

응답 기댓값: user에게 등록된 coupleId가 가진 country 속성을 기준으로 해당 국가의 가장 최신 뉴스 5개를 내림차순으로 호출  


### 테스트 결과
![image](https://github.com/OrangeCorpsKU/OC_server/assets/102205852/ba31c283-3978-4428-8813-030fe26bd402)

