### PR TITLE
feat: 뉴스 API 송신 방식 변경

### DIFF
--- a/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
+++ b/src/main/java/OrangeCorps/LBridge/Service/News/NewsService.java
@@ -62,8 +62,25 @@ public class NewsService {
 
     public List<NewsDTO> getNewsesOfCouple(String country) {
         List<NewsDTO> newsDTOs = new ArrayList<>();
-        for (int idx = NEWS_START_INDEX; idx < NEWS_END_INDEX; idx++) {
-            newsDTOs.add(getNewsOfCouple(idx, country));
+        Thread newsThread = new Thread(() -> {
+            for (int idx = NEWS_START_INDEX; idx <= NEWS_END_INDEX; idx++) {
+                try {
+                    newsDTOs.add(getNewsOfCouple(idx, country));
+                    Thread.sleep(13000);  // 13초 지연
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+
+        // 쓰레드 시작
+        newsThread.start();
+
+        try {
+            // 메인 쓰레드가 newsThread가 종료될 때까지 기다림
+            newsThread.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
         return newsDTOs;
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
main

### 변경 사항
뉴스 API 송신을 기존 5개씩 하루간격에서 API 송신 한 번당 13초의 간격을 두도록 하였습니다.
멀티쓰레딩으로 구현하여 기존 서버 운용에는 영향이 가지 않도록 하였습니다.
추후 도커로 따로 서버를 띄우는 방안도 검토해야 할 것 같습니다.
원인🔽
https://developer.nytimes.com/faq#a11
```
11. Is there an API call limit?
Yes, there are two rate limits per API: 500 requests per day and 5 requests per minute. You should sleep 12 seconds between calls to avoid hitting the per minute rate limit. If you need a higher rate limit, please contact us at code@nytimes.com.
```


### 테스트 결과

