### PR TITLE
feat: 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation("com.google.guava:guava:24.0-jre")
 	implementation("org.springframework.boot:spring-boot-starter-log4j2")
+	//websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.webjars:sockjs-client:1.1.2'
+	implementation 'org.webjars:stomp-websocket:2.3.3-1'
+
 
 	modules {
 		module("org.springframework.boot:spring-boot-starter-logging") {

--- a/src/main/java/OrangeCorps/LBridge/Chat/stomp/Domain/ChatMessage.java
+++ b/src/main/java/OrangeCorps/LBridge/Chat/stomp/Domain/ChatMessage.java
@@ -1,0 +1,24 @@
+package OrangeCorps.LBridge.Chat.stomp.Domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessage {
+    public enum MessageType {
+        ENTER, TALK
+    }
+
+    private MessageType type;
+    //채팅방 ID
+    private String roomId;
+    //보내는 사람
+    private String sender;
+    //내용
+    private String message;
+}

--- a/src/main/java/OrangeCorps/LBridge/Chat/stomp/Domain/ChatRoom.java
+++ b/src/main/java/OrangeCorps/LBridge/Chat/stomp/Domain/ChatRoom.java
@@ -1,0 +1,23 @@
+package OrangeCorps.LBridge.Chat.stomp.Domain;
+
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatRoom {
+
+    private String roomId;
+    private String roomName;
+
+
+    public static ChatRoom create(String name) {
+        ChatRoom room = new ChatRoom();
+        room.roomId = UUID.randomUUID().toString();
+        room.roomName = name;
+        return room;
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Chat/stomp/config/ChatConfig.java
+++ b/src/main/java/OrangeCorps/LBridge/Chat/stomp/config/ChatConfig.java
@@ -1,0 +1,26 @@
+package OrangeCorps.LBridge.Chat.stomp.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class ChatConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+
+        registry.enableSimpleBroker("/queue", "/topic");
+
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Chat/stomp/controller/ChatRoomController.java
+++ b/src/main/java/OrangeCorps/LBridge/Chat/stomp/controller/ChatRoomController.java
@@ -1,0 +1,46 @@
+package OrangeCorps.LBridge.Chat.stomp.controller;
+
+import OrangeCorps.LBridge.Chat.stomp.Domain.ChatRoom;
+import OrangeCorps.LBridge.Chat.stomp.service.ChatService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatRoomController {
+    private final ChatService chatService;
+
+
+    // 모든 채팅방 목록 반환
+    @GetMapping("/rooms")
+    @ResponseBody
+    public List<ChatRoom> room() {
+        return chatService.findAllRoom();
+    }
+
+    // 채팅방 생성
+    @PostMapping("/room")
+    @ResponseBody
+    public ChatRoom createRoom(@RequestParam String name) {
+        return chatService.createRoom(name);
+    }
+    // 채팅방 입장 화면
+
+    // 특정 채팅방 조회
+    @GetMapping("/room/{roomId}")
+    @ResponseBody
+    public ResponseEntity<ChatRoom> roomInfo(@PathVariable String roomId) {
+        ChatRoom chatRoom =  chatService.findById(roomId);
+        return new ResponseEntity<>(chatRoom, HttpStatus.OK);
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Chat/stomp/controller/MessageController.java
+++ b/src/main/java/OrangeCorps/LBridge/Chat/stomp/controller/MessageController.java
@@ -1,0 +1,22 @@
+package OrangeCorps.LBridge.Chat.stomp.controller;
+
+import OrangeCorps.LBridge.Chat.stomp.Domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final SimpMessageSendingOperations sendingOperations;
+
+    @MessageMapping("/chat/message")
+    public void enter(ChatMessage message) {
+        if (ChatMessage.MessageType.ENTER.equals(message.getType())) {
+            message.setMessage(message.getSender()+"님이 입장하였습니다.");
+        }
+        sendingOperations.convertAndSend("/topic/chat/room/"+message.getRoomId(),message);
+    }
+}

--- a/src/main/java/OrangeCorps/LBridge/Chat/stomp/service/ChatService.java
+++ b/src/main/java/OrangeCorps/LBridge/Chat/stomp/service/ChatService.java
@@ -1,0 +1,47 @@
+package OrangeCorps.LBridge.Chat.stomp.service;
+
+import OrangeCorps.LBridge.Chat.stomp.Domain.ChatRoom;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatService {
+
+    private Map<String, ChatRoom> chatRooms;
+
+    @PostConstruct
+    //의존관게 주입완료되면 실행되는 코드
+    private void init() {
+        chatRooms = new LinkedHashMap<>();
+    }
+
+    //채팅방 불러오기
+    public List<ChatRoom> findAllRoom() {
+        //채팅방 최근 생성 순으로 반환
+        List<ChatRoom> result = new ArrayList<>(chatRooms.values());
+        Collections.reverse(result);
+
+        return result;
+    }
+
+    //채팅방 하나 불러오기
+    public ChatRoom findById(String roomId) {
+        return chatRooms.get(roomId);
+    }
+
+    //채팅방 생성
+    public ChatRoom createRoom(String name) {
+        ChatRoom chatRoom = ChatRoom.create(name);
+        chatRooms.put(chatRoom.getRoomId(), chatRoom);
+        return chatRoom;
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature

### 변경 사항
stomp를 활용해 채팅방을 만들고 1대N 채팅이 가능한 기능을 구현하였습니다.
# 채팅방 생성

- POST /chat/room
- 매개변수
    - 매개변수 1: name
    - 매개변수 2: 설명

```json
{ "name" : "name"}
```

- 응답
    - `chatroom`
    - `resultCode`: 200OK
- 응답 예시
    
    ```json
    {
    	"roomId" : "asd",
    	"roomName" : "name"
    }
    ```
    

# 채팅 전송

- web-socket endpoint: /chat/room
- 웹 소켓 생성 후 웹 소켓의 메세지 형

```json

	{
        "type": "CHAT",
        "sender": {userID},
        "message": "하이요",
        "roomId": {roomId}
   }

```

- 응답 예시

### 테스트 결과

